### PR TITLE
Fix not to return error for unknown 手合割

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -47,6 +47,9 @@ export class InvalidLineError extends Error {
   }
 }
 
+/**
+ * @deprecated
+ */
 export class InvalidHandicapError extends Error {
   constructor(public data: string) {
     super(`Invalid handicap: ${data}`);

--- a/src/kakinoki.ts
+++ b/src/kakinoki.ts
@@ -9,7 +9,6 @@ import {
   InvalidBoardError,
   InvalidDestinationError,
   InvalidHandPieceError,
-  InvalidHandicapError,
   InvalidLineError,
   InvalidMoveError,
   InvalidMoveNumberError,
@@ -266,7 +265,7 @@ function parseLine(line: string): Line {
   };
 }
 
-function readHandicap(position: Position, data: string): Error | undefined {
+function readHandicap(position: Position, data: string) {
   switch (data.trim()) {
     case "平手":
       position.resetBySFEN(InitialPositionSFEN.STANDARD);
@@ -305,7 +304,10 @@ function readHandicap(position: Position, data: string): Error | undefined {
       position.resetBySFEN(InitialPositionSFEN.EMPTY);
       return;
   }
-  return new InvalidHandicapError(data);
+  // マイナビ系のソフトウェアは「手合割：詰将棋」を使用する場合がある。
+  // それを含め柿木将棋で規定していない値が使われるケースがしばしばあり、
+  // それらに対して適切な処理を判断しようがなく、
+  // エラーを返すわけにも行かないためここでは何もしない。
 }
 
 const stringToSpecialMoveType: { [move: string]: SpecialMoveType | undefined } = {
@@ -573,7 +575,7 @@ function importKakinoki(data: string, formatType: KakinokiFormatType): Record | 
         break;
       }
       case LineType.HANDICAP:
-        e = readHandicap(position, parsed.data);
+        readHandicap(position, parsed.data);
         break;
       case LineType.BLACK_HAND:
         e = readHand(position.blackHand, parsed.data);

--- a/src/tests/kakinoki.spec.ts
+++ b/src/tests/kakinoki.spec.ts
@@ -938,6 +938,40 @@ describe("shogi/kakinoki", () => {
     expect(record.current.comment).toBe("25手目のコメント\n");
   });
 
+  it("import/tsumeshogi", () => {
+    // 東大将棋6の詰将棋生成機能で作られた問題。
+    // 東大将棋6は手合割が「詰将棋」になっている。
+    const data = `
+# ---- 分岐棋譜(BKF)形式棋譜ファイル
+# ----   saved by IS-SHOGI
+手数：5手詰(参考)
+手合割：詰将棋　
+後手の持駒：飛二　角　金四　銀三　桂四　香四　歩十四　
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|一
+| ・ ・ ・ ・ ・ ・ ・ 銀 ・|二
+| ・ ・ ・ ・ ・ 歩 ・v玉 ・|三
+| ・ ・ ・ ・ ・ ・ ・v歩 歩|四
+| ・ ・ ・ ・ ・ ・ 歩 ・ ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| ・ ・ 角 ・ ・ ・ ・ ・ ・|七
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|八
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|九
++---------------------------+
+先手の持駒：なし
+先手番
+先手：
+後手：
+手数----指手---------消費時間--
+#--separator--
+`;
+    const record = importKIF(data) as Record;
+    expect(record).toBeInstanceOf(Record);
+    expect(record.moves).toHaveLength(1);
+    expect(record.position.sfen).toBe("9/7S1/5P1k1/7pP/6P2/9/2B6/9/9 b 2rb4g3s4n4l14p 1");
+  });
+
   it("import/ki2", () => {
     const data = `
 開始日時：1582/06/02 04:00:00


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/electron-shogi/issues/741

`手合割：詰将棋` を含めた未定義の手合割表記に対してエラーを返さないようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
