### PR TITLE
循環参照を解消

### DIFF
--- a/src/record.ts
+++ b/src/record.ts
@@ -184,9 +184,9 @@ export class RecordMetadata {
  */
 export interface ImmutableNode {
   readonly ply: number;
-  readonly prev: Node | null;
-  readonly next: Node | null;
-  readonly branch: Node | null;
+  readonly prev: ImmutableNode | null;
+  readonly next: ImmutableNode | null;
+  readonly branch: ImmutableNode | null;
   readonly branchIndex: number;
   readonly activeBranch: boolean;
   readonly nextColor: Color;
@@ -208,6 +208,9 @@ export interface ImmutableNode {
  * 棋譜を構成するノード
  */
 export interface Node extends ImmutableNode {
+  readonly prev: Node | null;
+  readonly next: Node | null;
+  readonly branch: Node | null;
   comment: string;
   customData: unknown;
   setElapsedMs(elapsedMs: number): void;


### PR DESCRIPTION

# 説明 / Description

`ImmutableNode` と `Node` が互いに参照し合っていた問題を解消しました。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
