### PR TITLE
型定義を改善

### DIFF
--- a/src/csa.ts
+++ b/src/csa.ts
@@ -52,7 +52,11 @@ enum SectionType {
   NEUTRAL,
 }
 
-const linePatterns = [
+const linePatterns: {
+  pattern: RegExp;
+  type: LineType;
+  sectionType: SectionType;
+}[] = [
   {
     pattern: /^V/,
     type: LineType.VERSION,
@@ -462,7 +466,9 @@ function formatMetadata(metadata: ImmutableRecordMetadata, options: CSAExportOpt
   return ret;
 }
 
-const pieceTypeToString = {
+const pieceTypeToString: {
+  [pieceType in PieceType]: string;
+} = {
   king: "OU",
   rook: "HI",
   dragon: "RY",

--- a/src/direction.ts
+++ b/src/direction.ts
@@ -1,4 +1,4 @@
-import { Piece } from "./piece";
+import { Piece, PieceType } from "./piece";
 
 export enum Direction {
   UP = "up",
@@ -15,7 +15,9 @@ export enum Direction {
   RIGHT_DOWN_KNIGHT = "right_down_knight",
 }
 
-const reverseMap = {
+const reverseMap: {
+  [direction in Direction]: Direction;
+} = {
   up: Direction.DOWN,
   down: Direction.UP,
   left: Direction.RIGHT,
@@ -38,7 +40,7 @@ export function reverseDirection(dir: Direction): Direction {
   return reverseMap[dir];
 }
 
-export const directions = [
+export const directions: Direction[] = [
   Direction.UP,
   Direction.DOWN,
   Direction.LEFT,
@@ -60,7 +62,7 @@ export enum MoveType {
 
 const movableDirectionMap: {
   [color: string]: {
-    [pieceType: string]: { [direction: string]: MoveType | undefined };
+    [pieceType in PieceType]: { [direction in Direction]?: MoveType | undefined };
   };
 } = {
   black: {
@@ -274,7 +276,7 @@ export function resolveMoveType(piece: Piece, direction: Direction): MoveType | 
 }
 
 export const directionToDeltaMap: {
-  [direction: string]: { x: number; y: number };
+  [direction in Direction]: { x: number; y: number };
 } = {
   up: { x: 0, y: -1 },
   down: { x: 0, y: 1 },

--- a/src/jkf.ts
+++ b/src/jkf.ts
@@ -35,7 +35,7 @@ export type JKFSquare = {
   kind?: JKFKind | null;
 };
 
-export type JKFHands = JKFHand[]; // 必ず 2 つの要素を持つ。
+export type JKFHands = [JKFHand, JKFHand];
 
 export type JKFHand = {
   FU?: number;

--- a/src/kakinoki.ts
+++ b/src/kakinoki.ts
@@ -88,7 +88,9 @@ export function kakinokiToMetadataKey(key: string): RecordMetadataKey | undefine
   return metadataKeyMap[key];
 }
 
-const metadataNameMap = {
+const metadataNameMap: {
+  [recordMetadataKey in RecordMetadataKey]: string;
+} = {
   [RecordMetadataKey.BLACK_NAME]: "先手",
   [RecordMetadataKey.WHITE_NAME]: "後手",
   [RecordMetadataKey.SHITATE_NAME]: "下手",
@@ -145,7 +147,12 @@ enum LineType {
   UNKNOWN,
 }
 
-const linePatterns = [
+const linePatterns: {
+  prefix: RegExp;
+  type: LineType;
+  removePrefix: boolean;
+  isPosition: boolean;
+}[] = [
   {
     prefix: /^#/,
     type: LineType.PROGRAM_COMMENT,
@@ -655,7 +662,9 @@ function importKakinoki(data: string, formatType: KakinokiFormatType): Record | 
   return record;
 }
 
-const specialMoveToString = {
+const specialMoveToString: {
+  [specialMoveType in SpecialMoveType]: string;
+} = {
   [SpecialMoveType.START]: "",
   [SpecialMoveType.RESIGN]: "投了",
   [SpecialMoveType.INTERRUPT]: "中断",

--- a/src/piece.ts
+++ b/src/piece.ts
@@ -17,7 +17,7 @@ export enum PieceType {
   DRAGON = "dragon",
 }
 
-const standardPieceNameMap: { [pieceType: string]: string } = {
+const standardPieceNameMap: { [pieceType in PieceType]: string } = {
   pawn: "歩",
   lance: "香",
   knight: "桂",
@@ -70,7 +70,7 @@ export const handPieceTypes: PieceType[] = [
   PieceType.ROOK,
 ];
 
-const promotable: { [pieceType: string]: boolean } = {
+const promotable: { [pieceType in PieceType]: boolean } = {
   pawn: true,
   lance: true,
   knight: true,
@@ -112,7 +112,7 @@ export function promotedPieceType(pieceType: PieceType): PieceType {
   return promoteMap[pieceType] || pieceType;
 }
 
-const unpromoteMap: { [pieceType: string]: PieceType } = {
+const unpromoteMap: { [pieceType in PieceType]?: PieceType } = {
   promPawn: PieceType.PAWN,
   promLance: PieceType.LANCE,
   promKnight: PieceType.KNIGHT,
@@ -129,7 +129,7 @@ export function unpromotedPieceType(pieceType: PieceType): PieceType {
   return unpromoteMap[pieceType] || pieceType;
 }
 
-const toSFENCharBlack: { [pieceType: string]: string } = {
+const toSFENCharBlack: { [pieceType in PieceType]: string } = {
   pawn: "P",
   lance: "L",
   knight: "N",
@@ -154,7 +154,7 @@ export function pieceTypeToSFEN(type: PieceType): string {
   return toSFENCharBlack[type];
 }
 
-const toSFENCharWhite: { [pieceType: string]: string } = {
+const toSFENCharWhite: { [pieceType in PieceType]: string } = {
   pawn: "p",
   lance: "l",
   knight: "n",

--- a/src/position.ts
+++ b/src/position.ts
@@ -73,7 +73,7 @@ export function initialPositionTypeToSFEN(type: InitialPositionType): string {
 }
 
 const invalidRankMap: {
-  [color: string]: { [pieceType: string]: { [rank: number]: boolean } };
+  [color: string]: { [pieceType in PieceType]?: { [rank: number]: boolean } };
 } = {
   black: {
     pawn: { 1: true },
@@ -692,20 +692,7 @@ export class Position {
 }
 
 type PieceCounts = {
-  pawn: number;
-  lance: number;
-  knight: number;
-  silver: number;
-  gold: number;
-  bishop: number;
-  rook: number;
-  king: number;
-  promPawn: number;
-  promLance: number;
-  promKnight: number;
-  promSilver: number;
-  horse: number;
-  dragon: number;
+  [pieceType in PieceType]: number;
 };
 
 export function countExistingPieces(position: ImmutablePosition): PieceCounts {

--- a/src/text.ts
+++ b/src/text.ts
@@ -115,7 +115,9 @@ export function rankToKanji(rank: number): string {
   return kanjiNumberStrings[rank - 1];
 }
 
-const pieceTypeToStringForMoveMap = {
+const pieceTypeToStringForMoveMap: {
+  [pieceType in PieceType]: string;
+} = {
   king: "玉",
   rook: "飛",
   dragon: "龍",
@@ -136,7 +138,9 @@ export function pieceTypeToStringForMove(pieceType: PieceType): string {
   return pieceTypeToStringForMoveMap[pieceType];
 }
 
-const pieceTypeToStringForBoardMap = {
+const pieceTypeToStringForBoardMap: {
+  [pieceType in PieceType]: string;
+} = {
   king: "玉",
   rook: "飛",
   dragon: "龍",
@@ -157,7 +161,9 @@ export function pieceTypeToStringForBoard(pieceType: PieceType): string {
   return pieceTypeToStringForBoardMap[pieceType];
 }
 
-const specialMoveToDisplayStringMap = {
+const specialMoveToDisplayStringMap: {
+  [specialMoveType in SpecialMoveType]: string;
+} = {
   [SpecialMoveType.START]: "開始局面",
   [SpecialMoveType.RESIGN]: "投了",
   [SpecialMoveType.INTERRUPT]: "中断",


### PR DESCRIPTION
# 説明 / Description

- 型の設定されていない一部の定数に型を設定
- enumの値をとる箇所で `[key: string]` となっていた型を `[key in Enum]` または `[key in Enum]?`に変更
    - すべてのenum値をとる場合は前者によってキーが不足するときに型エラーで検出可能に
    - 一部のenum値をとる場合は後者でenum値以外の文字列を設定できないように
- 要素数が固定の `JKFHands` を配列型からタプル型に変更

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
