### PR TITLE
Fix Record#append function

### DIFF
--- a/src/move.ts
+++ b/src/move.ts
@@ -146,3 +146,20 @@ export function anySpecialMove(name: string): AnySpecialMove {
 export function isKnownSpecialMove(move: Move | SpecialMove): move is PredefinedSpecialMove {
   return !(move instanceof Move) && move.type !== "any";
 }
+
+export function areSameSpecialMoves(a: SpecialMove, b: SpecialMove): boolean {
+  if (a.type === "any" && b.type === "any") {
+    return a.name === b.name;
+  }
+  return a.type === b.type;
+}
+
+export function areSameMoves(a: Move | SpecialMove, b: Move | SpecialMove): boolean {
+  if (a instanceof Move && b instanceof Move) {
+    return a.equals(b);
+  }
+  if (a instanceof Move || b instanceof Move) {
+    return false;
+  }
+  return areSameSpecialMoves(a, b);
+}

--- a/src/record.ts
+++ b/src/record.ts
@@ -1,7 +1,14 @@
 import { millisecondsToHHMMSS, millisecondsToMSS } from "./helpers/time";
 import { Color, reverseColor } from "./color";
 import { InvalidMoveError, InvalidUSIError } from "./errors";
-import { Move, SpecialMove, SpecialMoveType, parseUSIMove, specialMove } from "./move";
+import {
+  Move,
+  SpecialMove,
+  SpecialMoveType,
+  areSameMoves,
+  parseUSIMove,
+  specialMove,
+} from "./move";
 import { DoMoveOption, ImmutablePosition, InitialPositionSFEN, Position } from "./position";
 import { formatMove, formatSpecialMove } from "./text";
 
@@ -604,7 +611,7 @@ export class Record {
 
     // 特殊な指し手のノードの場合は前のノードに戻る。
     if (this._current !== this.first && !(this._current.move instanceof Move)) {
-      this.goBack();
+      this._goBack();
     }
 
     // 最終ノードの場合は単に新しいノードを追加する。
@@ -634,10 +641,7 @@ export class Record {
     // 同じ指し手が既に存在する場合はそのノードへ移動して終わる。
     let lastBranch = this._current.next;
     for (p = this._current.next; p; p = p.branch) {
-      if (
-        (p.move instanceof Move && move instanceof Move && move.equals(p.move)) ||
-        move === p.move
-      ) {
+      if (areSameMoves(move, p.move)) {
         this._current = p;
         this._current.activeBranch = true;
         this.onChangePosition();

--- a/src/tests/kakinoki.spec.ts
+++ b/src/tests/kakinoki.spec.ts
@@ -1057,30 +1057,28 @@ describe("shogi/kakinoki", () => {
     record.goto(1);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.RESIGN));
     record.switchBranchByIndex(1);
-    expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.RESIGN));
-    record.switchBranchByIndex(2);
     expect(record.current.move as SpecialMove).toStrictEqual(
       specialMove(SpecialMoveType.INTERRUPT),
     );
-    record.switchBranchByIndex(3);
+    record.switchBranchByIndex(2);
     expect(record.current.move as SpecialMove).toStrictEqual(
       specialMove(SpecialMoveType.REPETITION_DRAW),
     );
-    record.switchBranchByIndex(4);
+    record.switchBranchByIndex(3);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.IMPASS));
-    record.switchBranchByIndex(5);
+    record.switchBranchByIndex(4);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.TIMEOUT));
-    record.switchBranchByIndex(6);
+    record.switchBranchByIndex(5);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.FOUL_WIN));
-    record.switchBranchByIndex(7);
+    record.switchBranchByIndex(6);
     expect(record.current.move as SpecialMove).toStrictEqual(
       specialMove(SpecialMoveType.FOUL_LOSE),
     );
-    record.switchBranchByIndex(8);
+    record.switchBranchByIndex(7);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.MATE));
-    record.switchBranchByIndex(9);
+    record.switchBranchByIndex(8);
     expect(record.current.move as SpecialMove).toStrictEqual(specialMove(SpecialMoveType.NO_MATE));
-    record.switchBranchByIndex(10);
+    record.switchBranchByIndex(9);
     expect(record.current.move as SpecialMove).toStrictEqual(
       specialMove(SpecialMoveType.ENTERING_OF_KING),
     );

--- a/src/tests/record.spec.ts
+++ b/src/tests/record.spec.ts
@@ -127,49 +127,82 @@ describe("shogi/record", () => {
     const move = (ff: number, fr: number, tf: number, tr: number): Move => {
       return record.position.createMove(new Square(ff, fr), new Square(tf, tr)) as Move;
     };
+    // 76歩
     expect(record.append(move(7, 7, 7, 6))).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(1);
     expect(record.current.nextColor).toBe(Color.WHITE);
+    // 34歩
     expect(record.append(move(3, 3, 3, 4))).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(2);
     expect(record.current.nextColor).toBe(Color.BLACK);
+    // 26歩
     expect(record.append(move(2, 7, 2, 6))).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(3);
     expect(record.current.nextColor).toBe(Color.WHITE);
+    // go back
     expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(4);
+    // go back
     expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(5);
-    expect(record.append(move(8, 3, 8, 4))).toBeTruthy();
+    // 34歩 (again)
+    expect(record.append(move(3, 3, 3, 4))).toBeTruthy();
+    expect(record.current.hasBranch).toBeFalsy(); // 登録済みの指し手なので分岐は作られない。
     expect(onChangePosition).toBeCalledTimes(6);
-    expect(record.append(move(7, 9, 7, 8))).toBeTruthy();
+    // go back
+    expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(7);
-
-    expect(record.goBack()).toBeTruthy();
+    // 84歩
+    expect(record.append(move(8, 3, 8, 4))).toBeTruthy();
+    expect(record.current.hasBranch).toBeTruthy(); // 分岐が作られる。
     expect(onChangePosition).toBeCalledTimes(8);
-    expect(record.goBack()).toBeTruthy();
+    // 78金
+    expect(record.append(move(7, 9, 7, 8))).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(9);
+
+    // go back
     expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(10);
-    expect(record.usi).toBe("position startpos");
-    expect(record.goBack()).toBeFalsy();
-    expect(onChangePosition).toBeCalledTimes(10); // not called
-
-    expect(record.goForward()).toBeTruthy();
+    // go back
+    expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(11);
-    record.goto(Number.MAX_SAFE_INTEGER);
+    // go back
+    expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(12);
-    expect(record.usi).toBe("position startpos moves 7g7f 8c8d 7i7h");
-    expect(record.goForward()).toBeFalsy();
+    expect(record.usi).toBe("position startpos");
+    // go back (failed)
+    expect(record.goBack()).toBeFalsy();
     expect(onChangePosition).toBeCalledTimes(12); // not called
 
-    record.goto(2);
+    // go forward
+    expect(record.goForward()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(13);
-    expect(record.usi).toBe("position startpos moves 7g7f 8c8d");
-    record.goto(2);
-    expect(onChangePosition).toBeCalledTimes(13); // not called
-    expect(record.switchBranchByIndex(0)).toBeTruthy();
+    // go end
+    record.goto(Number.MAX_SAFE_INTEGER);
     expect(onChangePosition).toBeCalledTimes(14);
+    expect(record.usi).toBe("position startpos moves 7g7f 8c8d 7i7h");
+    // go forward (failed)
+    expect(record.goForward()).toBeFalsy();
+    expect(onChangePosition).toBeCalledTimes(14); // not called
+
+    // interrupt
+    expect(record.append(SpecialMoveType.INTERRUPT)).toBeTruthy();
+    expect(onChangePosition).toBeCalledTimes(15);
+    // interrupt (again)
+    expect(record.append(SpecialMoveType.INTERRUPT)).toBeTruthy();
+    expect(record.current.hasBranch).toBeFalsy(); // 登録済みの指し手なので分岐は増やさない。
+    expect(onChangePosition).toBeCalledTimes(16);
+
+    // go to 2nd move
+    record.goto(2);
+    expect(onChangePosition).toBeCalledTimes(17);
+    expect(record.usi).toBe("position startpos moves 7g7f 8c8d");
+    // go to 2nd move (no change)
+    record.goto(2);
+    expect(onChangePosition).toBeCalledTimes(17); // not called
+    // switch branch
+    expect(record.switchBranchByIndex(0)).toBeTruthy();
+    expect(onChangePosition).toBeCalledTimes(18);
     expect(record.usi).toBe("position startpos moves 7g7f 3c3d");
   });
 


### PR DESCRIPTION
# 説明 / Description

特殊な指し手を append したとき、同じ指し手が既に棋譜に存在している場合でも分岐を作ってしまう不具合を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced move comparison capabilities, allowing for more precise matching of different move types.
	- Improved move history navigation with added support for creating and switching branches, and handling special move types like interrupts.

- **Refactor**
	- Updated move comparison logic for better efficiency.

- **Tests**
	- Enhanced test coverage for various move scenarios, including special move types and move history navigation.

- **Style**
	- Renamed certain methods to improve clarity and internal consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->